### PR TITLE
Untitled

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -14,7 +14,7 @@ We use tabs, not spaces.
 * Use PascalCase for `enum` values
 * Use camelCase for `function` and `method` names
 * Use camelCase for `property` names and `local variables`
-* Use whole words in names when possiblej
+* Use whole words in names when possible
 
 ## Types
 


### PR DESCRIPTION
Fix a typo in the coding guidelines.

* Correct the typo "possiblej" to "possible" in the Naming Conventions section.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/sangshanrupesh/vscode/pull/5?shareId=cd531c18-940e-4962-a4ae-09a613038559).